### PR TITLE
Refactor Speedometer and Fix filtered speed decrement bug

### DIFF
--- a/src/filter/emafilter.cpp
+++ b/src/filter/emafilter.cpp
@@ -1,29 +1,29 @@
 #include "emafilter.h"
 
-EmaFilter::EmaFilter(QObject* parent, float alpha)
+EmaFilter::EmaFilter(QObject* parent, double alpha)
     : IFilter(parent), alpha(alpha), oneMinusAlpha(1.0f - alpha), ema(0.0f)
 {}
 
 EmaFilter::~EmaFilter()
 {}
 
-float EmaFilter::getEma() const
+double EmaFilter::getEma() const
 {
     return this->ema;
 }
 
-void EmaFilter::setEma(float value)
+void EmaFilter::setEma(double value)
 {
     this->ema = value;
 }
 
-void EmaFilter::setAlpha(float value)
+void EmaFilter::setAlpha(double value)
 {
     this->alpha = value;
     this->oneMinusAlpha = 1 - value;
 }
 
-float EmaFilter::calculateFilteredOutput(float value)
+double EmaFilter::calculateFilteredOutput(double value)
 {
     this->ema = this->alpha * value + this->oneMinusAlpha * ema;
     return this->ema;

--- a/src/filter/emafilter.h
+++ b/src/filter/emafilter.h
@@ -6,19 +6,19 @@
 class EmaFilter : public IFilter
 {
 public:
-    explicit EmaFilter(QObject* parent, float alpha = 0.2);
+    explicit EmaFilter(QObject* parent, double alpha = 0.2);
     ~EmaFilter();
 
-    float getEma() const;
-    void setEma(float value);
-    void setAlpha(float value);
-    float calculateFilteredOutput(float value) override;
+    double getEma() const;
+    void setEma(double value);
+    void setAlpha(double value);
+    double calculateFilteredOutput(double value) override;
     void reset() override;
 
 private:
-    float alpha;
-    float oneMinusAlpha;
-    float ema;
+    double alpha;
+    double oneMinusAlpha;
+    double ema;
 };
 
 #endif // EMAFILTER_H

--- a/src/filter/filtermanager.cpp
+++ b/src/filter/filtermanager.cpp
@@ -14,9 +14,9 @@ FilterManager::FilterManager(QObject *parent)
 FilterManager::~FilterManager()
 {}
 
-float FilterManager::filter(float value)
+double FilterManager::filter(double value)
 {
-    float filteredValue = value;
+    double filteredValue = value;
 
     for (auto filterPtr : this->activeFilters)
     {

--- a/src/filter/filtermanager.h
+++ b/src/filter/filtermanager.h
@@ -21,7 +21,7 @@ public:
     };
     Q_ENUM(FilterType)
 
-    float filter(float value);
+    double filter(double value);
     Q_INVOKABLE void addFilter(FilterType type);
     Q_INVOKABLE void removeFilter(FilterType type);
     void reset();

--- a/src/filter/ifilter.h
+++ b/src/filter/ifilter.h
@@ -10,7 +10,7 @@ public:
     explicit IFilter(QObject *parent = nullptr): QObject(parent) {}
     virtual ~IFilter() {};
 
-    virtual float calculateFilteredOutput(float value) = 0;
+    virtual double calculateFilteredOutput(double value) = 0;
     virtual void reset() = 0;
 };
 

--- a/src/filter/kalmanfilter.cpp
+++ b/src/filter/kalmanfilter.cpp
@@ -1,6 +1,6 @@
 #include "kalmanfilter.h"
 
-KalmanFilter::KalmanFilter(QObject* parent, float processNoise, float measurementNoise, float estimationError)
+KalmanFilter::KalmanFilter(QObject* parent, double processNoise, double measurementNoise, double estimationError)
     : IFilter(parent)
     , processNoise(processNoise)
     , measurementNoise(measurementNoise)
@@ -13,7 +13,7 @@ KalmanFilter::KalmanFilter(QObject* parent, float processNoise, float measuremen
 
 KalmanFilter::~KalmanFilter() {}
 
-void KalmanFilter::setProcessNoise(float valueP, float valueM, float valueR)
+void KalmanFilter::setProcessNoise(double valueP, double valueM, double valueR)
 {
     this->processNoise = valueP;
     this->measurementNoise = valueM;
@@ -21,7 +21,7 @@ void KalmanFilter::setProcessNoise(float valueP, float valueM, float valueR)
     this->initialEstimationError = valueR;
 }
 
-float KalmanFilter::calculateFilteredOutput(float measurement)
+double KalmanFilter::calculateFilteredOutput(double measurement)
 {
     // Estimation step
     this->estimationError += this->processNoise;

--- a/src/filter/kalmanfilter.h
+++ b/src/filter/kalmanfilter.h
@@ -7,22 +7,22 @@ class KalmanFilter : public IFilter
 {
 public:
     explicit KalmanFilter(QObject* parent
-                          , float processNoise = 1.0f
-                          , float measurementNoise = 10.0f
-                          , float estimationError = 100.0f);
+                          , double processNoise = 1.0f
+                          , double measurementNoise = 10.0f
+                          , double estimationError = 100.0f);
     ~KalmanFilter();
 
-    void setProcessNoise(float valueP, float valueM, float valueR);
-    float calculateFilteredOutput(float measurement) override;
+    void setProcessNoise(double valueP, double valueM, double valueR);
+    double calculateFilteredOutput(double measurement) override;
     void reset() override;
 
 private:
-    float processNoise;
-    float measurementNoise;
-    float estimationError;
-    float kalmanGain;
-    float currentEstimate;
-    float initialEstimationError;
+    double processNoise;
+    double measurementNoise;
+    double estimationError;
+    double kalmanGain;
+    double currentEstimate;
+    double initialEstimationError;
 };
 
 #endif // KALMANFILTER_H

--- a/src/filter/smafilter.cpp
+++ b/src/filter/smafilter.cpp
@@ -21,7 +21,7 @@ void SmaFilter::setFilterParameters(int windowSize)
     reset();
 }
 
-float SmaFilter::calculateFilteredOutput(float value)
+double SmaFilter::calculateFilteredOutput(double value)
 {
     this->sum -= buffer[currentIndex];
     buffer[currentIndex] = value;
@@ -33,7 +33,7 @@ float SmaFilter::calculateFilteredOutput(float value)
         this->count++;
     }
 
-    return static_cast<float>(this->sum) / this->count;
+    return this->sum / this->count;
 }
 
 void SmaFilter::reset()

--- a/src/filter/smafilter.h
+++ b/src/filter/smafilter.h
@@ -16,15 +16,15 @@ public:
     ~SmaFilter();
 
     void setFilterParameters(int length);
-    float calculateFilteredOutput(float value) override;
+    double calculateFilteredOutput(double value) override;
     void reset() override;
 
 private:
     int windowSize;
-    std::array<float, MAX_BUFFER_SIZE> buffer;
+    std::array<double, MAX_BUFFER_SIZE> buffer;
     int currentIndex;
     int count;
-    int sum;
+    double sum;
 };
 
 #endif // SMAFILTER_H

--- a/src/qml/Speedometer.qml
+++ b/src/qml/Speedometer.qml
@@ -4,10 +4,19 @@ import QtQuick.Layouts 1.15
 
 Item {
     id: speedometer
-    property real speed: 0
-    property real animatedSpeed: 0
     width: 300
     height: 300
+
+    property real speed: 0
+    property real animatedSpeed: 0
+
+    // Numeric speed
+    readonly property string speedFont: "italic bold 30px Arial"
+    readonly property string unitFont: "italic 13px Arial"
+
+    // Speed gauge
+    readonly property real gaugeStartAngle: 150
+    property var gradient: null
 
     onSpeedChanged: {
         speedAnimation.to = speed;
@@ -25,7 +34,7 @@ Item {
                 updateTimer.start();
             } else {
                 updateTimer.stop();
-                canvas.requestPaint();
+                foregroundCanvas.requestPaint();
             }
         }
     }
@@ -35,11 +44,11 @@ Item {
         interval: 16  // 60fps
         repeat: true
         running: false
-        onTriggered: canvas.requestPaint()
+        onTriggered: foregroundCanvas.requestPaint()
     }
 
     Canvas {
-        id: canvas
+        id: backgroundCanvas
         anchors.fill: parent
         onPaint: {
             let ctx = getContext("2d");
@@ -47,66 +56,89 @@ Item {
             ctx.translate(width / 2, height / 2);
             ctx.clearRect(-width / 2, -height / 2, width, height);
 
-            // Draw Background
-            ctx.beginPath();
-            ctx.arc(0, 0, 140, 0, 2 * Math.PI);
-            ctx.fillStyle = "black";
-            ctx.fill();
+            // drawBackground(ctx);
+            drawScale(ctx);
+        }
+    }
 
-            // Draw Scale
-            ctx.strokeStyle = "white";
-            for (let i = 0; i <= 240; i += 4) {
-                ctx.save();
-                ctx.rotate((240 + i) * Math.PI / 180);
-                if (i % 40 === 0) {
-                    ctx.lineWidth = 2;
-                    ctx.beginPath();
-                    ctx.moveTo(0, -125);
-                    ctx.lineTo(0, -140);
-                    ctx.stroke();
-                    ctx.translate(0, -107);
-                } else if (i % 20 === 0) {
-                    ctx.lineWidth = 1;
-                    ctx.beginPath();
-                    ctx.moveTo(0, -130);
-                    ctx.lineTo(0, -140);
-                    ctx.stroke();
-                } else {
-                    ctx.lineWidth = 1;
-                    ctx.beginPath();
-                    ctx.moveTo(0, -135);
-                    ctx.lineTo(0, -140);
-                    ctx.stroke();
-                }
-                ctx.restore();
-            }
+    function drawBackground(ctx) {
+        ctx.beginPath();
+        ctx.arc(0, 0, 140, 0, 2 * Math.PI);
+        ctx.fillStyle = "black";
+        ctx.fill();
+    }
 
-            // speed gauge
-            if (animatedSpeed > 0) {
-                let gaugeStartAngle = 150;
-                let gaugeEndAngle = gaugeStartAngle + animatedSpeed;
-
-                let gradient = ctx.createLinearGradient(-150, 0, 150, 0);
-                gradient.addColorStop(0, "skyblue");  // Start color
-                gradient.addColorStop(1, "purple");   // End color
-                ctx.strokeStyle = gradient;
-
-                ctx.lineWidth = 10;
+    function drawScale(ctx) {
+        ctx.strokeStyle = "white";
+        for (let i = 0; i <= 240; i += 4) {
+            ctx.save();
+            ctx.rotate((240 + i) * Math.PI / 180);
+            if (i % 40 === 0) {
+                ctx.lineWidth = 2;
                 ctx.beginPath();
-                ctx.arc(0, 0, 110, gaugeStartAngle * Math.PI / 180, gaugeEndAngle * Math.PI / 180);
+                ctx.moveTo(0, -125);
+                ctx.lineTo(0, -140);
+                ctx.stroke();
+                ctx.translate(0, -107);
+            } else if (i % 20 === 0) {
+                ctx.lineWidth = 1;
+                ctx.beginPath();
+                ctx.moveTo(0, -130);
+                ctx.lineTo(0, -140);
+                ctx.stroke();
+            } else {
+                ctx.lineWidth = 1;
+                ctx.beginPath();
+                ctx.moveTo(0, -135);
+                ctx.lineTo(0, -140);
                 ctx.stroke();
             }
-
-            // Draw Speed Info Text
-            ctx.font = "italic bold 30px Arial";
-            ctx.fillStyle = "white";
-            let speedText = Math.round(animatedSpeed).toString();
-            let textMetrics = ctx.measureText(speedText);
-            ctx.fillText(speedText, -textMetrics.width / 2, 0);
-
-            ctx.font = "italic 13px Arial";
-            textMetrics = ctx.measureText("cm/s");
-            ctx.fillText("cm/s", -textMetrics.width / 2, 20);
+            ctx.restore();
         }
+    }
+
+    Canvas {
+        id: foregroundCanvas
+        anchors.fill: parent
+        onAvailableChanged: {
+            if (available) {
+                let ctx = getContext("2d");
+                gradient = ctx.createLinearGradient(-150, 0, 150, 0);
+                gradient.addColorStop(0, "skyblue");  // Start color
+                gradient.addColorStop(1, "purple");   // End color
+                requestPaint();
+            }
+        }
+        onPaint: {
+            let ctx = getContext("2d");
+            ctx.reset();
+            ctx.translate(width / 2, height / 2);
+
+            drawSpeedGauge(ctx);
+            drawNumericText(ctx);
+        }
+    }
+
+    function drawSpeedGauge(ctx) {
+        if (animatedSpeed > 0) {
+            let gaugeEndAngle = gaugeStartAngle + animatedSpeed * 0.8;
+            ctx.strokeStyle = gradient;
+            ctx.lineWidth = 10;
+            ctx.beginPath();
+            ctx.arc(0, 0, 110, gaugeStartAngle * Math.PI / 180, gaugeEndAngle * Math.PI / 180);
+            ctx.stroke();
+        }
+    }
+
+    function drawNumericText(ctx) {
+        ctx.font = speedFont;
+        ctx.fillStyle = "white";
+        let speedText = Math.round(animatedSpeed).toString();
+        let textMetrics = ctx.measureText(speedText);
+        ctx.fillText(speedText, -textMetrics.width / 2, 0);
+
+        ctx.font = unitFont;
+        textMetrics = ctx.measureText("cm/s");
+        ctx.fillText("cm/s", -textMetrics.width / 2, 20);
     }
 }

--- a/src/speedupdatemanager.cpp
+++ b/src/speedupdatemanager.cpp
@@ -48,7 +48,7 @@ void SpeedUpdateManager::processSpeedData()
             stream.setByteOrder(QDataStream::LittleEndian);
             stream >> scaledSpeed;
 
-            float speed = this->filterManager->filter(static_cast<float>(scaledSpeed / this->SCALE_FACTOR));
+            double speed = this->filterManager->filter(static_cast<double>(scaledSpeed) / this->SCALE_FACTOR);
             if (speed < 1.0f)
             {
                 this->filterManager->reset();

--- a/src/speedupdatemanager.h
+++ b/src/speedupdatemanager.h
@@ -24,7 +24,7 @@ private:
     CanReceiver* canReceiver;
     FilterManager* filterManager;
 
-    const float	SCALE_FACTOR = 10000.0;
+    const double SCALE_FACTOR = 10000.0;
 
     void processSpeedData();
 


### PR DESCRIPTION
- Refactored for better readability.
- Now speed scale UI is drawn only once at start.
- Assigned strings to properties so that Javascript engine does not parse and create temporal instances every time when it renders.
- There was a problem when the actual speed of PiRacer does not change but the filtered speed shown in screen gets gradually decreased. I changed every `float` to `double` which has much higher precision so that there will be much less error while calculation.